### PR TITLE
remove tablse_csv as it breaks the json decode

### DIFF
--- a/code/mthfr.py
+++ b/code/mthfr.py
@@ -71,7 +71,6 @@ class MTHFR(Condition):
         # json file
         result_dic = {
             "dianogstic_score": self.diagnostic_risk_association,
-            "table_csv" : self.snp_results.to_csv(None, index=False, sep='\t'),
             "data" : self.snp_results.to_dict(orient='records')
         }
 


### PR DESCRIPTION
I am removing the `table_csv` property of the dic because it leads to parsing errors in the app